### PR TITLE
Enable print functionality and add print styles

### DIFF
--- a/apps/web/src/app/(auth)/dashboard/payments/receipt/page.tsx
+++ b/apps/web/src/app/(auth)/dashboard/payments/receipt/page.tsx
@@ -38,7 +38,7 @@ export default function PaymentReceiptPage() {
   });
 
   const handlePrint = () => {
-    // TODO
+    window.print();
   };
 
   const handleDownload = () => {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -21,3 +21,29 @@
   --font-lemon-mocktail: "Lemon Mocktail", sans-serif;
   --font-star-avenue: "Star Avenue", sans-serif;
 }
+
+@media print {
+  body * {
+    visibility: hidden;
+  }
+  
+  .print\:shadow-none,
+  .print\:shadow-none * {
+    visibility: visible;
+  }
+  
+  .print\:shadow-none {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+  }
+  
+  .print\:hidden {
+    display: none !important;
+  }
+  
+  .print\:border-none {
+    border: none !important;
+  }
+}


### PR DESCRIPTION
Implemented the print action in the payment receipt page by calling window.print(). Added print-specific CSS rules to control visibility, borders, and shadows for better print layout.